### PR TITLE
chore: extend startupProbe timeout seconds of altlayer operator chart

### DIFF
--- a/charts/altlayer-multi-mach-operator/values.yaml
+++ b/charts/altlayer-multi-mach-operator/values.yaml
@@ -117,6 +117,7 @@ node:
       port: 9092
     initialDelaySeconds: 30
     periodSeconds: 10
+    timeoutSeconds: 30
   readinessProbe:
     httpGet:
       path: /metrics


### PR DESCRIPTION
Extend altlayer multi mach operator startupProbe timeout to 30s