### PR TITLE
feat: add etherfi ccdata api key env

### DIFF
--- a/charts/eoracle/values.yaml
+++ b/charts/eoracle/values.yaml
@@ -29,7 +29,8 @@ env:
   EO_PROMETHEUS_PORT: "10004"
   EO_HEALTH_ENDPOINTS_PORT: "10003"
   EO_LOGGING_LEVEL: info
-
+  EO_CCDATA_API_KEY: ""
+  
 secrets:
   blsKey: ""
   ecdsaAliasedKey: ""


### PR DESCRIPTION
etherfi env가 추가되어 차트에도 추가합니다.(EO_CCDATA_API_KEY) operator별로 다르게 key가 주어지기 때문에 default value의 기본값은 비워둡니다.