### PR TITLE
feat(arpa): add log sidecar

### DIFF
--- a/charts/arpa/templates/statefulset.yaml
+++ b/charts/arpa/templates/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
         - name: log-sidecar
           image: busybox:1.34.0
           imagePullPolicy: IfNotPresent
-          args: ["/bin/sh", "-c", "tail -f /app/log/node.log"]
+          args: ["/bin/sh", "-c", "tail -f /app/log/node.log  /app/log/node_err.log"]
           volumeMounts:
           - name: arpa-pvc
             mountPath: "/app/log"

--- a/charts/arpa/templates/statefulset.yaml
+++ b/charts/arpa/templates/statefulset.yaml
@@ -124,6 +124,14 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.sealedSecrets.arpaNodeKeyPassword.name }}
                   key: password
+        - name: log-sidecar
+          image: busybox:1.34.0
+          imagePullPolicy: IfNotPresent
+          args: ["/bin/sh", "-c", "tail -f /app/log/node.log"]
+          volumeMounts:
+          - name: arpa-pvc
+            mountPath: "/app/log"
+            subPath: log
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/arpa/values.yaml
+++ b/charts/arpa/values.yaml
@@ -11,8 +11,7 @@ replicas: 1
 
 network: ""
 
-nodeSelector:
-  a41.io/project: ""
+nodeSelector: {}
 
 image:
   repository: ghcr.io/arpa-network/node-client


### PR DESCRIPTION
# 문제
- arpa 메인 컨테이너의 로그는 설정내용만 보여주고 끝남
  <img width="1428" alt="Screenshot 2024-10-18 at 9 01 03 PM" src="https://github.com/user-attachments/assets/5ce82a3c-3e39-4c67-bb1c-8614f30f75c9">
- 실제 실행 로그는 `/app/log/node.log` 파일에 기록되어 컨테이너를 들어가야만 볼수 있음

# 해결 방안
- log 출력용 컨테이너를 띄워 tail -f 를 활용해 로그를 쉽게 볼수 있도록 개선
<img width="1863" alt="Screenshot 2024-10-18 at 9 02 51 PM" src="https://github.com/user-attachments/assets/6f033a95-4ccf-412c-9555-a2c8fe49e776">

# 추가 수정 사항
- nodeSelector 기본값이 `a41.io/project: ""`로 되어있어 `ci/default-values.yaml` 로 테스트 작성시 nodeSelector를 비워주어야 하는 문제가 있음. 간단하게 패치함
