### PR TITLE
Add CI secret handling logic

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,10 +73,19 @@ jobs:
       #     helm repo update
       #     helm install prometheus prometheus-community/kube-prometheus-stack
 
-      # Inject Secrets
-      - name: Inject dummy keystores as secret
+      # Inject Necessary Secrets
+      - name: Inject necessaries as secret
         if: steps.list-changed.outputs.changed == 'true'
         run: |
+          echo -n '${{ secrets.DOCKERHUB_TOKEN }}' > .dockerconfigjson
+          kubectl create secret generic dockerhub-secret --from-file=.dockerconfigjson
+
+      # Inject Dummy Secrets
+      - name: Inject dummy keys as secret
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          echo -n '${{ secrets.DUMMY_ECDSA_PRIVATE_KEY }}' > privateKey
+          kubectl create secret generic dummy-ecdsa-private-key --from-file=privateKey
           echo -n '${{ secrets.DUMMY_ECDSA_KEYSTORE }}' > keystore.json
           kubectl create secret generic dummy-ecdsa-keystore --from-file=keystore.json
           echo -n '${{ secrets.DUMMY_ECDSA_PASSWORD }}' > password


### PR DESCRIPTION
CI 테스트 과정 중 엣지 케이스 핸들링을 위해 필요한 내용을 추가했습니다

1. 프라이빗 레포로부터 컨테이너 이미지를 받기 위한 dockerhub-secret 시크릿 추가
2. 배포 시에 ECDSA 키스토어가 아닌 프라이빗키를 요구하는 AVS 경우를 위해 dummy-ecdsa-private-key 시크릿 추가

이를 위해 레포 환경변수에 알맞은 값 추가가 필요합니다!
1. DOCKERHUB_TOKEN
2. DUMMY_ECDSA_PRIVATE_KEY