### PR TITLE
feat(eigenda): add support for v2

### DIFF
--- a/charts/eigenda/templates/configmap.yaml
+++ b/charts/eigenda/templates/configmap.yaml
@@ -75,7 +75,7 @@ data:
 
   # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
   # In future release, this will be removed
-  NODE_QUORUM_ID_LIST: {{ .Values.quorumIdList }}
+  NODE_QUORUM_ID_LIST: {{ .Values.quorumIdList | quote }}
 
   NODE_VERBOSE: "true"
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}

--- a/charts/eigenda/templates/configmap.yaml
+++ b/charts/eigenda/templates/configmap.yaml
@@ -17,6 +17,17 @@ data:
         }
     }
     server {
+        listen ${NODE_V2_RETRIEVAL_PORT};
+        client_max_body_size 1M;
+        http2 on;
+        location / {
+            limit_req zone=ip burst=${BURST_LIMIT} nodelay;
+            limit_req_status 429;
+            grpc_set_header X-Real-IP $remote_addr;
+            grpc_pass grpc://${NODE_HOST}:${NODE_INTERNAL_V2_RETRIEVAL_PORT};
+        }
+    }
+    server {
         listen ${NODE_API_PORT};
         client_max_body_size 1M;
         http2 on;
@@ -39,7 +50,9 @@ data:
   NODE_API_PORT: {{ .Values.apiPort | quote }}
   NODE_INTERNAL_API_PORT: {{ .Values.internalApiPort | quote }}
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
+  NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
   NODE_INTERNAL_RETRIEVAL_PORT: {{ .Values.internalRetrievalPort | quote }}
+  NODE_INTERNAL_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -55,6 +68,10 @@ data:
   NODE_CACHE_ENCODED_BLOBS: "true"
   NODE_NUM_WORKERS: "1"
   NODE_DISPERSAL_PORT: {{ .Values.dispersalPort | quote }}
+  NODE_V2_DISPERSAL_PORT: {{ .Values.v2DispersalPort | quote }}
+
+  # This flag defines a runtime mode. Acceptable inputs are v1-only, v2-only, v1-and-v2
+  NODE_RUNTIME_MODE: "v1-and-v2"
 
   # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
   # In future release, this will be removed
@@ -62,6 +79,7 @@ data:
 
   NODE_VERBOSE: "true"
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
+  NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
   NODE_TIMEOUT: 20s
   NODE_SRS_ORDER: "268435456"
   NODE_SRS_LOAD: "8388608"
@@ -71,6 +89,8 @@ data:
   # $NODE_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_DISPERSAL_PORT.
   NODE_INTERNAL_DISPERSAL_PORT: {{ .Values.dispersalPort | quote }}
   NODE_INTERNAL_RETRIEVAL_PORT: {{ .Values.internalRetrievalPort | quote }}
+  NODE_INTERNAL_V2_DISPERSAL_PORT: {{ .Values.v2DispersalPort | quote }}
+  NODE_INTERNAL_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
 
   # Reachability Check
   NODE_REACHABILITY_POLL_INTERVAL: "60"

--- a/charts/eigenda/templates/configmap.yaml
+++ b/charts/eigenda/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
 
   NODE_VERBOSE: "true"
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
-  NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
+  NODE_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
   NODE_TIMEOUT: 20s
   NODE_SRS_ORDER: "268435456"
   NODE_SRS_LOAD: "8388608"

--- a/charts/eigenda/templates/service.yaml
+++ b/charts/eigenda/templates/service.yaml
@@ -23,5 +23,13 @@ spec:
       port: {{ .Values.dispersalPort }}
       protocol: TCP
       targetPort: dispersal
+    - name: v2-retrieval
+      port: {{ .Values.v2RetrievalPort }}
+      protocol: TCP
+      targetPort: v2-retrieval
+    - name: v2-dispersal
+      port: {{ .Values.v2DispersalPort }}
+      protocol: TCP
+      targetPort: v2-dispersal
   selector:
     {{- include "eigenda.selectorLabels" . | nindent 4 }}

--- a/charts/eigenda/templates/statefulset.yaml
+++ b/charts/eigenda/templates/statefulset.yaml
@@ -96,7 +96,7 @@ spec:
             name: int-retrieval
           - containerPort: {{ .Values.internalV2RetrievalPort }}
             protocol: TCP
-            name: int-v2-retrieval
+            name: int-v2-rtrvl
           - containerPort: {{ .Values.internalApiPort }}
             protocol: TCP
             name: int-api

--- a/charts/eigenda/templates/statefulset.yaml
+++ b/charts/eigenda/templates/statefulset.yaml
@@ -56,7 +56,7 @@ spec:
             - name: NODE_OPERATION
               value: "update-socket"
             - name: NODE_SOCKET
-              value: "$(NODE_HOSTNAME):$(NODE_DISPERSAL_PORT);$(NODE_RETRIEVAL_PORT)"
+              value: "$(NODE_HOSTNAME):$(NODE_DISPERSAL_PORT);$(NODE_RETRIEVAL_PORT);$(NODE_V2_DISPERSAL_PORT);$(NODE_V2_RETRIEVAL_PORT)"
             - name: NODE_BLS_KEY_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/charts/eigenda/templates/statefulset.yaml
+++ b/charts/eigenda/templates/statefulset.yaml
@@ -94,6 +94,9 @@ spec:
           - containerPort: {{ .Values.internalRetrievalPort }}
             protocol: TCP
             name: int-retrieval
+          - containerPort: {{ .Values.internalV2RetrievalPort }}
+            protocol: TCP
+            name: int-v2-retrieval
           - containerPort: {{ .Values.internalApiPort }}
             protocol: TCP
             name: int-api
@@ -174,6 +177,9 @@ spec:
           - containerPort: {{ .Values.retrievalPort }}
             protocol: TCP
             name: retrieval
+          - containerPort: {{ .Values.v2RetrievalPort }}
+            protocol: TCP
+            name: v2-retrieval
           - containerPort: {{ .Values.apiPort }}
             protocol: TCP
             name: api

--- a/charts/eigenda/values.yaml
+++ b/charts/eigenda/values.yaml
@@ -58,14 +58,19 @@ persistence:
   # Read more (https://github.com/rancher/local-path-provisioner)
   storageClassName: "local-path"
 
+runtimeMode: "v1-and-v2"
+
 # -- Internal Retrieval Port
 internalRetrievalPort: 32003
+internalV2RetrievalPort: 32008
 
 # -- Retrieval Port
 retrievalPort: 32004
+v2RetrievalPort: 32007
 
 # -- Dispersal Port
 dispersalPort: 32005
+v2DispersalPort: 32006
 
 # -- Node Internal API Port
 internalApiPort: 9090
@@ -127,7 +132,7 @@ nodeHostname: ""
 # EigenDA quorum id list
 # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
 # In future release, this will be removed
-quorumIdList: "0,1"
+quorumIdList: "0"
 
 # Initcontainer configuration
 initContainers:
@@ -154,7 +159,7 @@ initContainers:
     image:
       repository: ghcr.io/layr-labs/eigenda/opr-nodeplugin
       pullPolicy: Always
-      tag: "0.8.5"
+      tag: "0.9.0-rc.0"
 
 # Node configuration
 node:
@@ -163,7 +168,7 @@ node:
   image:
     repository: ghcr.io/layr-labs/eigenda/opr-node
     pullPolicy: Always
-    tag: "0.8.5"
+    tag: "0.9.0-rc.0"
   securityContext: {}
   resources:
     limits:


### PR DESCRIPTION
eigenda-operator-setup 레포의 변경사항을 반영합니다.
https://github.com/Layr-Labs/eigenda-operator-setup/compare/ab4470070f2cad97336c0a4107e7da55a5018051...0f7bf5a9271806cfed5a06fce3c22ba11b009c14

## Copilot Summary
This pull request includes several changes to the `charts/eigenda` configuration files to support a new runtime mode and additional ports. The most important changes are related to the addition of new ports and the update of image tags.

### Configuration Updates:

* [`charts/eigenda/templates/configmap.yaml`](diffhunk://#diff-f891af9a53f26b91cd78749274f692eef5f3a87945f8508ea903a94f3c44d374R19-R29): Added new server block configurations and variables for `NODE_V2_RETRIEVAL_PORT` and `NODE_INTERNAL_V2_RETRIEVAL_PORT`. [[1]](diffhunk://#diff-f891af9a53f26b91cd78749274f692eef5f3a87945f8508ea903a94f3c44d374R19-R29) [[2]](diffhunk://#diff-f891af9a53f26b91cd78749274f692eef5f3a87945f8508ea903a94f3c44d374R53-R55) [[3]](diffhunk://#diff-f891af9a53f26b91cd78749274f692eef5f3a87945f8508ea903a94f3c44d374R71-R82) [[4]](diffhunk://#diff-f891af9a53f26b91cd78749274f692eef5f3a87945f8508ea903a94f3c44d374R92-R93)

### StatefulSet Updates:

* [`charts/eigenda/templates/statefulset.yaml`](diffhunk://#diff-9061d965626fb0b20f392f49475de5ffce34c27938d3470f107e8ca216cae5beL59-R59): Updated the `NODE_SOCKET` environment variable to include `NODE_V2_DISPERSAL_PORT` and `NODE_V2_RETRIEVAL_PORT`.

### Values File Updates:

* [`charts/eigenda/values.yaml`](diffhunk://#diff-dede25e726ba9e025dba835b13114dbb7b6efba5d4b5d164f48d2dc55848d97eR61-R73): Added new configuration values for `runtimeMode`, `internalV2RetrievalPort`, `v2RetrievalPort`, and `v2DispersalPort`. Updated `quorumIdList` and image tags to `0.9.0-rc.0`. [[1]](diffhunk://#diff-dede25e726ba9e025dba835b13114dbb7b6efba5d4b5d164f48d2dc55848d97eR61-R73) [[2]](diffhunk://#diff-dede25e726ba9e025dba835b13114dbb7b6efba5d4b5d164f48d2dc55848d97eL130-R135) [[3]](diffhunk://#diff-dede25e726ba9e025dba835b13114dbb7b6efba5d4b5d164f48d2dc55848d97eL157-R162) [[4]](diffhunk://#diff-dede25e726ba9e025dba835b13114dbb7b6efba5d4b5d164f48d2dc55848d97eL166-R171)