### PR TITLE
feat: zenrock checksum

### DIFF
--- a/charts/zenrock/templates/deployment.yaml
+++ b/charts/zenrock/templates/deployment.yaml
@@ -20,8 +20,9 @@ spec:
       {{- include "zenrock.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/charts/zenrock/templates/pvc.yaml
+++ b/charts/zenrock/templates/pvc.yaml
@@ -11,4 +11,6 @@ spec:
     requests:
       storage: {{ .Values.zenrock.persistence.size }}
   storageClassName: {{ .Values.zenrock.persistence.storageClass }}
+  selector:
+    {{- include "zenrock.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/zenrock/templates/pvc.yaml
+++ b/charts/zenrock/templates/pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ printf "%s-data" (include "zenrock.fullname" .) }}
+  labels:
+    {{- include "zenrock.labels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
This pull request includes changes to the `charts/zenrock/templates` directory to enhance the configuration of deployments and persistent volume claims (PVCs). The most important changes include adding a checksum annotation for the configuration and including selector labels for PVCs.

Enhancements to deployment configuration:

* [`charts/zenrock/templates/deployment.yaml`](diffhunk://#diff-bd862645436e172c1b9e9c3938a5e8e6f4a55414ab10a88920162cedd365cfdaL23-R25): Added a checksum annotation for the configuration file to ensure that changes to the configmap trigger a pod restart.

Enhancements to PVC configuration:

* [`charts/zenrock/templates/pvc.yaml`](diffhunk://#diff-6da9e0d19b64ae7285ea54c9c9eb0b234f6d2304a19db5ec095a4b4f4f65f7c4R14-R15): Included selector labels to the PVC specification to ensure proper labeling and selection of PVCs.