### PR TITLE
Modify miss matching NODE_V2_RETRIEVAL_PORT in EigenDA's configmap

### DIFF
--- a/charts/eigenda/templates/configmap.yaml
+++ b/charts/eigenda/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
 
   NODE_VERBOSE: "true"
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
-  NODE_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
+  NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
   NODE_TIMEOUT: 20s
   NODE_SRS_ORDER: "268435456"
   NODE_SRS_LOAD: "8388608"


### PR DESCRIPTION
- ConfigMap의 `NODE_V2_RETRIEVAL_PORT` 필드가 `{{ .Values.internalV2RetrievalPort }}` 로 잘못 세팅되어 있는걸 바로 잡았습니다