### PR TITLE
Clarify EigenDA ports configurations

### DIFF
--- a/charts/eigenda/templates/configmap.yaml
+++ b/charts/eigenda/templates/configmap.yaml
@@ -46,13 +46,19 @@ metadata:
 data:
   REQUEST_LIMIT: "10r/s"
   BURST_LIMIT: "50"
+
   NODE_HOST: localhost
-  NODE_API_PORT: {{ .Values.apiPort | quote }}
-  NODE_INTERNAL_API_PORT: {{ .Values.internalApiPort | quote }}
+
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
   NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
+  NODE_API_PORT: {{ .Values.apiPort | quote }}
+
+  # If you are using a reverse proxy in a shared network space, the reverse proxy should listen at $NODE_DISPERSAL_PORT
+  # and forward the traffic to $NODE_INTERNAL_DISPERSAL_PORT, and similarly for retrieval. The DA node will register the
+  # $NODE_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_DISPERSAL_PORT.
   NODE_INTERNAL_RETRIEVAL_PORT: {{ .Values.internalRetrievalPort | quote }}
   NODE_INTERNAL_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
+  NODE_INTERNAL_API_PORT: {{ .Values.internalApiPort | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -69,6 +75,11 @@ data:
   NODE_NUM_WORKERS: "1"
   NODE_DISPERSAL_PORT: {{ .Values.dispersalPort | quote }}
   NODE_V2_DISPERSAL_PORT: {{ .Values.v2DispersalPort | quote }}
+  NODE_RETRIEVAL_PORT: {{ .Values.internalRetrievalPort | quote }}
+  NODE_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
+  NODE_TIMEOUT: 20s
+  NODE_SRS_ORDER: "268435456"
+  NODE_SRS_LOAD: "8388608"
 
   # This flag defines a runtime mode. Acceptable inputs are v1-only, v2-only, v1-and-v2
   NODE_RUNTIME_MODE: "v1-and-v2"
@@ -76,21 +87,6 @@ data:
   # This is a dummy value for now. This won't be used as we are explicitly asking for quorum while opting in/out
   # In future release, this will be removed
   NODE_QUORUM_ID_LIST: {{ .Values.quorumIdList | quote }}
-
-  NODE_VERBOSE: "true"
-  NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
-  NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
-  NODE_TIMEOUT: 20s
-  NODE_SRS_ORDER: "268435456"
-  NODE_SRS_LOAD: "8388608"
-
-  # If you are using a reverse proxy in a shared network space, the reverse proxy should listen at $NODE_DISPERSAL_PORT
-  # and forward the traffic to $NODE_INTERNAL_DISPERSAL_PORT, and similarly for retrieval. The DA node will register the
-  # $NODE_DISPERSAL_PORT port on the chain and listen for the reverse proxy at $NODE_INTERNAL_DISPERSAL_PORT.
-  NODE_INTERNAL_DISPERSAL_PORT: {{ .Values.dispersalPort | quote }}
-  NODE_INTERNAL_RETRIEVAL_PORT: {{ .Values.internalRetrievalPort | quote }}
-  NODE_INTERNAL_V2_DISPERSAL_PORT: {{ .Values.v2DispersalPort | quote }}
-  NODE_INTERNAL_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
 
   # Reachability Check
   NODE_REACHABILITY_POLL_INTERVAL: "60"
@@ -112,6 +108,7 @@ data:
   NODE_DB_PATH: /data/operator/db
 
   # Node logs configs
+  NODE_VERBOSE: "true"
   NODE_LOG_LEVEL: debug
   NODE_LOG_FORMAT: text
 

--- a/charts/eigenda/templates/configmap.yaml
+++ b/charts/eigenda/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
 
   NODE_VERBOSE: "true"
   NODE_RETRIEVAL_PORT: {{ .Values.retrievalPort | quote }}
-  NODE_V2_RETRIEVAL_PORT: {{ .Values.internalV2RetrievalPort | quote }}
+  NODE_V2_RETRIEVAL_PORT: {{ .Values.v2RetrievalPort | quote }}
   NODE_TIMEOUT: 20s
   NODE_SRS_ORDER: "268435456"
   NODE_SRS_LOAD: "8388608"

--- a/charts/eigenda/templates/statefulset.yaml
+++ b/charts/eigenda/templates/statefulset.yaml
@@ -94,15 +94,6 @@ spec:
           - containerPort: {{ .Values.v2DispersalPort }}
             protocol: TCP
             name: v2-dispersal
-          - containerPort: {{ .Values.internalRetrievalPort }}
-            protocol: TCP
-            name: int-retrieval
-          - containerPort: {{ .Values.internalV2RetrievalPort }}
-            protocol: TCP
-            name: int-v2-rtrvl
-          - containerPort: {{ .Values.internalApiPort }}
-            protocol: TCP
-            name: int-api
           - containerPort: {{ .Values.metricsPort }}
             protocol: TCP
             name: metrics


### PR DESCRIPTION
 - `proxy` 가 존재하기 때문에 `node` 컨테이너에서는 오픈할 포트가 `internal*` 로 설정되는게 맞는거 같습니다
     헷갈리지않게 차트를 일부 수정했습니다
- 각 컨테이너에 불필요하게 오픈된 포트와 ConfigMap 에 세팅된 env 변수 정리했습니다